### PR TITLE
pin node version to 16 or 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "stylelint-config-gds": "^0.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^16 || ^18"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^16 || ^18"
   },
   "prototype": {
     "serviceName": "Give or refuse consent for vaccinations",


### PR DESCRIPTION
As per https://github.com/x-govuk/govuk-prototype-rig/pull/184 the prototype build fails with certain newer versions of node. This commit mimics the fix implemented in a different commit, however:

https://github.com/x-govuk/govuk-prototype-rig/commit/7d6bbd1bd379ee24a8a4ed6fc0a627c0126c8f1f

Pinning the version of node to 16 and 18.