### PR TITLE
Ability to set no preference for telephone contact method

### DIFF
--- a/app/views/consent/check-answers.html
+++ b/app/views/consent/check-answers.html
@@ -120,8 +120,13 @@
             href: basePath + "consent/parent-guardian?change=true"
           },
           {
-            key: "Phone number",
+            key: "Telephone number",
             data: "parent.telephone",
+            href: basePath + "consent/parent-guardian?change=true"
+          },
+          {
+            key: "Telephone contact method",
+            data: "parent.accessibility",
             href: basePath + "consent/parent-guardian?change=true"
           }
         ])

--- a/app/views/consent/check-answers.html
+++ b/app/views/consent/check-answers.html
@@ -121,14 +121,18 @@
           },
           {
             key: "Telephone number",
-            data: "parent.telephone",
+            value: {
+              text: data.parent.telephone | default("Not provided", true)
+            },
             href: basePath + "consent/parent-guardian?change=true"
           },
           {
             key: "Telephone contact method",
-            data: "parent.accessibility",
-            href: basePath + "consent/parent-guardian?change=true"
-          }
+            value: {
+              text: d("parent.accessibility") + " – " + d("parent.accessibility-details") if d("parent.accessibility") == "Other" else data.parent.accessibility | default("Not provided", true)
+            },
+            href: basePath + "consent/telephone-contact-method?change=true"
+          } if data.parent.telephone
         ])
       }) }}
     </div>

--- a/app/views/consent/parent-guardian.html
+++ b/app/views/consent/parent-guardian.html
@@ -68,48 +68,11 @@
 
   {{ input({
     label: {
-      text: "Telephone number"
+      text: "Telephone number (optional)"
     },
     hint: {
       text: "A nurse might call you about your child’s vaccination"
     },
     decorate: "parent.telephone"
-  }) }}
-
-  {% set otherHtml %}
-    {{ textarea({
-      label: {
-        text: "Give details"
-      },
-      rows: 5,
-      formGroup: {
-        classes: "nhsuk-u-margin-bottom-0"
-      },
-      decorate: "parent.accessibility-other"
-    }) }}
-  {% endset %}
-
-  {{ radios({
-    fieldset: {
-      legend: {
-        text: "Telephone contact method"
-      }
-    },
-    hint: {
-      text: "Tell us if you have specific needs"
-    },
-    items: [
-      { text: "I can only receive text messages" },
-      { text: "I can only receive voice calls" },
-      {
-        text: "Other",
-        conditional: {
-          html: otherHtml
-        }
-      },
-      { divider: "or" },
-      { text: "I do not have specific needs" }
-    ],
-    decorate: "parent.accessibility"
   }) }}
 {% endblock %}

--- a/app/views/consent/parent-guardian.html
+++ b/app/views/consent/parent-guardian.html
@@ -76,42 +76,40 @@
     decorate: "parent.telephone"
   }) }}
 
-  {% set accessibilityOptions %}
-    {% set otherHtml %}
-      {{ textarea({
-        label: {
-          text: "Give details"
-        },
-        rows: 5,
-        formGroup: {
-          classes: "nhsuk-u-margin-bottom-0"
-        },
-        decorate: "parent.accessibility-other"
-      }) }}
-    {% endset %}
-
-    {{ radios({
-      fieldset: {
-        legend: {
-          text: "Do you need any of the following?"
-        }
+  {% set otherHtml %}
+    {{ textarea({
+      label: {
+        text: "Give details"
       },
-      items: [
-        { text: "Text only (no voice calls)" },
-        { text: "Voice only (no text)" },
-        {
-          text: "Other",
-          conditional: {
-            html: otherHtml
-          }
-        }
-      ],
-      decorate: "parent.accessibility"
+      rows: 5,
+      formGroup: {
+        classes: "nhsuk-u-margin-bottom-0"
+      },
+      decorate: "parent.accessibility-other"
     }) }}
   {% endset %}
 
-  {{ details({
-    text: "I need to tell you more about how to contact me",
-    HTML: accessibilityOptions
+  {{ radios({
+    fieldset: {
+      legend: {
+        text: "Telephone contact method"
+      }
+    },
+    hint: {
+      text: "Tell us if you have specific needs"
+    },
+    items: [
+      { text: "I can only receive text messages" },
+      { text: "I can only receive voice calls" },
+      {
+        text: "Other",
+        conditional: {
+          html: otherHtml
+        }
+      },
+      { divider: "or" },
+      { text: "I do not have specific needs" }
+    ],
+    decorate: "parent.accessibility"
   }) }}
 {% endblock %}

--- a/app/views/consent/telephone-contact-method.html
+++ b/app/views/consent/telephone-contact-method.html
@@ -1,0 +1,43 @@
+{% extends "layouts/wizard.html" %}
+{% set title = "Telephone contact method" %}
+
+{% block form %}
+  {% set html %}
+    {{ textarea({
+      label: {
+        text: "Give details"
+      },
+      rows: 5,
+      formGroup: {
+        classes: "nhsuk-u-margin-bottom-0"
+      },
+      decorate: "parent.accessibility-details"
+    }) }}
+  {% endset %}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        text: title,
+        isPageHeading: true
+      }
+    },
+    hint: {
+      text: "Tell us if you have specific needs"
+    },
+    items: [
+      { text: "I can only receive text messages" },
+      { text: "I can only receive voice calls" },
+      {
+        text: "Other",
+        conditional: {
+          html: html
+        }
+      },
+      { divider: "or" },
+      { text: "I do not have specific needs" }
+    ],
+    decorate: "parent.accessibility"
+  }) }}
+{% endblock %}

--- a/app/wizards/flu.js
+++ b/app/wizards/flu.js
@@ -18,7 +18,9 @@ export function fluWizard (req) {
       }
     },
     '/flu/consent/parent-guardian': {
-      '/flu/consent/no-parental-responsibility': noParentalResponsibility
+      '/flu/consent/no-parental-responsibility': noParentalResponsibility,
+      '/flu/consent/telephone-contact-method': () =>
+        !noParentalResponsibility && req.session.data.parent.telephone !== ''
     },
     '/flu/consent/consent': {
       '/flu/consent/child-gp': consentedNasal


### PR DESCRIPTION
Currently this question is hidden behind a disclosure. If you select an option, you cannot then unselect it:

<img width="665" alt="Screenshot 2023-09-11 at 14 58 41" src="https://github.com/nhsuk/consent-for-vaccinations-prototype/assets/813383/c53786cc-0f45-4c72-a4f6-f2093a67ddad">

This PR removes the disclosure and shows the question to everyone, adding a ‘I do not have specific needs’ option:

<img width="675" alt="Screenshot 2023-09-11 at 14 50 43" src="https://github.com/nhsuk/consent-for-vaccinations-prototype/assets/813383/dbf6c684-e5fc-4ba5-ab86-fe20f468b13e">

It also plays back the answer on the Check your answers page:

<img width="1000" alt="Screenshot 2023-09-11 at 15 01 02" src="https://github.com/nhsuk/consent-for-vaccinations-prototype/assets/813383/5d239613-6e34-4ca3-813d-bca8cd29f5a7">

