### PR TITLE
Flag someone without parental responsibility

### DIFF
--- a/app/views/consent/no-parental-responsibility.html
+++ b/app/views/consent/no-parental-responsibility.html
@@ -1,0 +1,14 @@
+{% extends "layouts/default.html" %}
+{% set title = "You cannot give or refuse consent through this service" %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-l">{{ title }}</h1>
+
+      <p>To give or refuse consent for a child’s vaccination, you need to have parental responsibility.</p>
+
+      <p>If you have any questions, please contact the local health team by calling 01234 321456, or email <a href="mailto:example@nhs.uk">example@nhs.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/consent/parent-guardian.html
+++ b/app/views/consent/parent-guardian.html
@@ -12,7 +12,6 @@
   }) }}
 
   {% set other %}
-    <p>You need parental responsibility to give consent. This means you have legal rights and duties relating to the child.</p>
     {{ input({
       label: {
         text: "Relationship to the child"
@@ -21,6 +20,22 @@
         text: "For example, carer"
       },
       decorate: "parent.relationship-other"
+    }) }}
+
+    {{ radios({
+      fieldset: {
+        legend: {
+          text: "Do you have parental responsibility?"
+        }
+      },
+      hint: {
+        text: "This means you have legal rights and duties relating to the child"
+      },
+      items: [
+        { text: "Yes" },
+        { text: "No" }
+      ],
+      decorate: "parent.has-responsibility"
     }) }}
   {% endset %}
 

--- a/app/wizards/flu.js
+++ b/app/wizards/flu.js
@@ -5,6 +5,7 @@ export function fluWizard (req) {
   const consentedNasal = req.session.data.consent !== 'No'
   const consentedJabContact = req.session.data['im-consent'] !== 'No'
   const anyContraindications = checkForContraindications(req.session.data.health)
+  const noParentalResponsibility = req.session.data.parent.relationship === 'Other' && req.session.data.parent['has-responsibility'] === 'No'
 
   const journey = {
     '/flu/start': {},
@@ -16,7 +17,9 @@ export function fluWizard (req) {
         value: 'No, they go to a different school'
       }
     },
-    '/flu/consent/parent-guardian': {},
+    '/flu/consent/parent-guardian': {
+      '/flu/consent/no-parental-responsibility': noParentalResponsibility
+    },
     '/flu/consent/consent': {
       '/flu/consent/child-gp': consentedNasal
     },


### PR DESCRIPTION
Add question asking if user has parental responsibility (if they select ‘Other’ for relationship to child):

<img width="680" alt="Screenshot 2023-09-11 at 16 58 08" src="https://github.com/nhsuk/consent-for-vaccinations-prototype/assets/813383/6a6fe156-fa8c-49e5-a61b-a1c43026140d">

If they select ‘No’, show a page saying they cannot use this service:

<img width="680" alt="Screenshot 2023-09-11 at 16 57 35" src="https://github.com/nhsuk/consent-for-vaccinations-prototype/assets/813383/594fc557-a3c6-4b07-87cb-d1ac133037b7">
