### PR TITLE
Add data placeholders for session school and dates

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -27,9 +27,9 @@ export default (env) => {
    */
 
   // example: 7 December 2021
-  filters.dateWithYear = params => {
-    const datetime = DateTime.local(parseInt(params.year), parseInt(params.month), parseInt(params.day))
-    return datetime.toFormat('d MMMM yyyy')
+  filters.date = (string, format = 'd MMMM yyyy') => {
+    const datetime = DateTime.fromISO(string)
+    return datetime.toFormat(format)
   }
 
   // stringify an object

--- a/app/routes.js
+++ b/app/routes.js
@@ -13,6 +13,11 @@ router.all('*', (req, res, next) => {
   } else {
     res.locals.childName = 'Bobby Doe'
   }
+
+  res.locals.deadlineDate = '2023-11-24'
+  res.locals.sessionDate = '2023-11-27'
+  res.locals.sessionSchool = res.locals.secondary ? 'Hele’s Secondary School' : 'St Mary’s Primary School'
+
   next()
 })
 

--- a/app/views/consent/check-answers.html
+++ b/app/views/consent/check-answers.html
@@ -80,7 +80,7 @@
           } if consented,
           {
             key: "School",
-            value: "Hele’s Secondary School",
+            value: sessionSchool,
             href: basePath + "consent/school?change=true"
           },
           {

--- a/app/views/consent/confirmation.html
+++ b/app/views/consent/confirmation.html
@@ -6,17 +6,17 @@
 
 {% set title %}
   {% if vaccine == "HPV" %}
-    Your child will get their first HPV vaccination at school on 6 June 2023
+    Your child will get their first HPV vaccination at school on {{ sessionDate | govukDate }}
   {% elseif vaccine == "DPT" %}
     {% if consentForBoth %}
-      Your child will get their 3-in-1 teenage booster and MenACWY vaccinations at school on 6 June 2023
+      Your child will get their 3-in-1 teenage booster and MenACWY vaccinations at school on {{ sessionDate | govukDate }}
     {% elseif 3in1consent %}
-      Your child will get their 3-in-1 teenage booster at school on 6 June 2023
+      Your child will get their 3-in-1 teenage booster at school on {{ sessionDate | govukDate }}
     {% elseif menACWYconsent %}
-      Your child will get their MenACWY vaccination at school on 6 June 2023
+      Your child will get their MenACWY vaccination at school on {{ sessionDate | govukDate }}
     {% endif %}
   {% else %}
-    Your child will get their nasal flu vaccination at school on 6 June 2023
+    Your child will get their nasal flu vaccination at school on {{ sessionDate | govukDate }}
   {% endif %}
 {% endset %}
 

--- a/app/views/consent/school.html
+++ b/app/views/consent/school.html
@@ -7,11 +7,7 @@
   {% set html %}
     <p>
       <span class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
-        {% if secondary %}
-          Hele’s Secondary School
-        {% else %}
-          St Mary’s Primary School
-        {% endif %}
+        {{ sessionSchool }}
       </span>
       PL1 1AA
     </p>

--- a/app/views/dpt/confirmation.html
+++ b/app/views/dpt/confirmation.html
@@ -22,14 +22,11 @@
     rows: decorateRows([
       {
         key: { text: "Date" },
-        value: { text: "Tuesday 21 November 2022" }
+        value: { text: sessionDate | date("cccc d MMMM yyyy") }
       },
       {
         key: { text: "Location" },
-        value: { text: "Hele’s Secondary School" }
-      } if secondary else {
-        key: { text: "Location" },
-        value: { text: "St Mary’s Primary School" }
+        value: { text: sessionSchool }
       },
       {
         key: { text: "Vaccine" },

--- a/app/views/emails/flu-consent-confirmation.html
+++ b/app/views/emails/flu-consent-confirmation.html
@@ -1,12 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Flu vaccination on 24 November" %}
+{% set subject = "Flu vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set name = parent.name or "Jane Doe" %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>You’ve agreed for {{ childName }} to have their flu vaccination at Boringdon Primary School on Monday 24 November.</p>
+  <p>You’ve agreed for {{ childName }} to have their flu vaccination at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
   <p>We’ll let you know once they’re vaccinated.</p>
 

--- a/app/views/emails/flu-consent-injection.html
+++ b/app/views/emails/flu-consent-injection.html
@@ -1,12 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Flu vaccination on 24 November" %}
+{% set subject = "Flu vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set name = parent.name or "Jane Doe" %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>You’ve told us you do not want {{ childName }} to have their flu vaccination at Boringdon Primary School on Monday 24 November because of the gelatine in the nasal spray.</p>
+  <p>You’ve told us you do not want {{ childName }} to have their flu vaccination at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }} because of the gelatine in the nasal spray.</p>
 
   <p>A nurse will be in touch to talk about the possibility of them having an injection instead.</p>
 

--- a/app/views/emails/flu-consent-needs-triage.html
+++ b/app/views/emails/flu-consent-needs-triage.html
@@ -1,12 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Flu vaccination on 24 November" %}
+{% set subject = "Flu vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set name = parent.name or "Jane Doe" %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>You’ve said you agree to {{ childName }} having their flu vaccination at Boringdon Primary School on Monday 24 November.</p>
+  <p>You’ve said you agree to {{ childName }} having their flu vaccination at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
   <p>As you answered ‘yes’ to some of the health questions, we need to check the vaccination is suitable for Jamie. We’ll review your answers and get in touch again soon.</p>
 

--- a/app/views/emails/flu-consent-triage-complete.html
+++ b/app/views/emails/flu-consent-triage-complete.html
@@ -1,5 +1,5 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Your child can have a flu vaccination on 24 November" %}
+{% set subject = "Your child can have a flu vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set name = parent.name or "Jane Doe" %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
@@ -8,9 +8,9 @@
 
   <p>Thanks for answering the health questions about {{ childName }}. Our nurses have confirmed it’s safe for {{ childName.split(" ") | first }} to have the nasal flu vaccination.</p>
 
-  <p>This will take place at Boringdon Primary School on Monday 24 November.</p>
+  <p>This will take place at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
-  <p>We’ll let you know once Jamie is vaccinated.</p>
+  <p>We’ll let you know once {{ childName.split(" ") | first }} is vaccinated.</p>
 
   <p>If {{ childName.split(" ") | first }}’s health changes, or you arrange to have the vaccination elsewhere, please get in touch. You can email example@nhs.uk or call 01234 321456.</p>
 

--- a/app/views/emails/flu-consent.html
+++ b/app/views/emails/flu-consent.html
@@ -1,9 +1,9 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Flu vaccination on 24 November" %}
+{% set subject = "Flu vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
-  <p>Your local health team are coming to [name of school] on Monday 24 November 2023 to give this year’s flu vaccine.</p>
+  <p>Your local health team are coming to {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }} to give this year’s flu vaccine.</p>
 
   <h2 class="nhsuk-heading-m">What the vaccine is for</h2>
 
@@ -13,7 +13,7 @@
 
   <h2 class="nhsuk-heading-m">Please give or refuse consent</h2>
 
-  <p>If you want your child to get this vaccine at school, you need to give consent by Monday 2 October.</p>
+  <p>If you want your child to get this vaccine at school, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
 
   <p>
     <a href="/flu/start">Give or refuse consent for the flu vaccination</a>

--- a/app/views/emails/flu-refusal-confirmation.html
+++ b/app/views/emails/flu-refusal-confirmation.html
@@ -1,12 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Flu vaccination on 24 November" %}
+{% set subject = "Flu vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set name = parent.name or "Jane Doe" %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>You’ve told us you do not want {{ childName }} to have their flu vaccination at Boringdon Primary School on Monday 24 November.</p>
+  <p>You’ve told us you do not want {{ childName }} to have their flu vaccination at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
   <p>If you change your mind, please get in touch with us. You can email example@nhs.uk or call 01234 321456.</p>
 

--- a/app/views/emails/flu-reminder.html
+++ b/app/views/emails/flu-reminder.html
@@ -1,11 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Please respond to our request for consent by 21 November" %}
+{% set subject = "Please respond to our request for consent by " + (deadlineDate | date("d MMMM")) %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
-  <p>We wrote to you recently about a visit by a local health team to [name of school] on Monday 24 November.</p>
+  <p>We wrote to you recently about a visit by a local health team to {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
-  <p>If you want your child to get the flu vaccine during this visit, you need to give consent by Friday 21 November.</p>
+  <p>If you want your child to get the flu vaccine during this visit, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
+
 
   <p>
     <a href="/flu/start">Give or refuse consent for the flu vaccination</a>

--- a/app/views/emails/flu-vaccine-given.html
+++ b/app/views/emails/flu-vaccine-given.html
@@ -6,14 +6,17 @@
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>{{ childName }} had their flu vaccination at Boringdon Primary School today. They were very brave.</p>
+  <p>
+    {{ childName }} had their flu vaccination at {{ sessionSchool }} today.
+    {% if primary %}They were very brave.{% endif %}
+  </p>
 
   <p>We suggest you record the following details in their red book (also known as their personal child health record):</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>Vaccination: Seasonal flu</li>
     <li>Vaccine: Fluenz Tetra</li>
-    <li>Date of vaccination: 8 November 2023</li>
+    <li>Date of vaccination: {{ sessionDate | govukDate }}</li>
     <li>Batch number: PH3539</li>
   </ul>
 

--- a/app/views/emails/hpv-consent-confirmation.html
+++ b/app/views/emails/hpv-consent-confirmation.html
@@ -1,12 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Your child will get the HPV vaccine on 6 June" %}
+{% set subject = "Your child will get the HPV vaccine on " + (sessionDate | date("d MMMM")) %}
 {% set name = parent.name or "Jane Doe" %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>You’ve agreed for {{ childName }} to get the HPV vaccination at Hele’s School. The first dose will be given on Tuesday 6 June.</p>
+  <p>You’ve agreed for {{ childName }} to get the HPV vaccination at {{ sessionSchool }}. The first dose will be given on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
   <p>We’ll let you know when the vaccine has been given.</p>
 

--- a/app/views/emails/hpv-consent.html
+++ b/app/views/emails/hpv-consent.html
@@ -1,9 +1,9 @@
 {% extends "layouts/email.html" %}
-{% set subject = "HPV vaccination on 6 June" %}
+{% set subject = "HPV vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
-  <p>Your local health team are coming to [name of school] on Tuesday 6 June 2023 to give the first dose of the human papillomavirus (HPV) vaccine to pupils in Year 8.</p>
+  <p>Your local health team are coming to {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }} to give the first dose of the human papillomavirus (HPV) vaccine to pupils in Year 8.</p>
 
   <h2 class="nhsuk-heading-m">What the vaccine is for</h2>
 
@@ -21,7 +21,7 @@
 
   <h2 class="nhsuk-heading-m">Please give or refuse consent</h2>
 
-  <p>If you want your child to get this vaccine at school, you need to give consent by Friday 2 June.</p>
+  <p>If you want your child to get this vaccine at school, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
 
   <p>
     <a href="/hpv/start">Give or refuse consent for the HPV vaccination</a>

--- a/app/views/emails/hpv-reminder.html
+++ b/app/views/emails/hpv-reminder.html
@@ -1,11 +1,11 @@
 {% extends "layouts/email.html" %}
-{% set subject = "Please respond to our request for consent by 2 June" %}
+{% set subject = "Please respond to our request for consent by " + (deadlineDate | date("d MMMM")) %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
-  <p>We wrote to you recently about a visit by a local health team to [name of school] on Tuesday 6 June 2023.</p>
+  <p>We wrote to you recently about a visit by a local health team to {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
-  <p>If you want your child to receive an HPV vaccine during this visit, you need to give consent by Friday 2 June.</p>
+  <p>If you want your child to receive an HPV vaccine during this visit, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
 
   <p>
     <a href="/hpv/start">Give or refuse consent for the HPV vaccination</a>

--- a/app/views/emails/hpv-student.html
+++ b/app/views/emails/hpv-student.html
@@ -1,12 +1,12 @@
 {% extends "layouts/email.html" %}
-{% set subject = "You can get an HPV vaccination on 6 June" %}
+{% set subject = "You can get an HPV vaccination on " + (sessionDate | date("d MMMM")) %}
 {% set from = "School vaccinations <school.vaccinations@nhs.net>" %}
 
 {% block email %}
-  <p>A team of nurses are coming to your school on 6 June 2023 to offer everyone in Year 8 a vaccine that protects you from something called the human papillomavirus. This is known as ‘HPV’ for short.
-</p>
+  <p>A team of nurses are coming to your school on {{ sessionDate | govukDate }} to offer everyone in Year 8 a vaccine that protects you from something called the human papillomavirus. This is known as ‘HPV’ for short.</p>
 
   <h2 class="nhsuk-heading-m">What is HPV?</h2>
+
   <p>HPV is a virus that most people will get at some point in their life. Some types of HPV cause cancer.</p>
 
   <h2 class="nhsuk-heading-m">Why does the NHS offer the vaccine?</h2>
@@ -24,6 +24,7 @@
   <h2 class="nhsuk-heading-m">How does the vaccine work?</h2>
 
   <p>When the vaccine is injected into your body, your immune system makes antibodies. If you got HPV in the future, these antibodies would stop the virus from infecting your cells.</p>
+
   <p>The vaccine is given in your arm, and you need two doses to be fully protected.</p>
 
   <p>It works best if it’s given before you’re sexually active.</p>
@@ -31,7 +32,8 @@
   <h2 class="nhsuk-heading-m">How do I get the vaccine?</h2>
 
   <p>The nurses coming into school can only give you the vaccine if they have permission. We’ve contacted your parents and asked if they’re happy for you to have the vaccine.</p>
-  <p>If they tell us they are happy, all you need to do is come to school as normal on 6 June. One of the nurses will have a quick chat with you and then give you the vaccine.</p>
+
+  <p>If they tell us they are happy, all you need to do is come to school as normal on {{ sessionDate | date("d MMMM") }}. One of the nurses will have a quick chat with you and then give you the vaccine.</p>
 
   <p>If your parents don’t get back to us, or if they say they’re not happy for you to have the vaccine, you can:</p>
 
@@ -40,13 +42,13 @@
     <li>give the nurses permission yourself</li>
   </ul>
 
-  <p>If you want to give permission yourself, you can talk to a nurse on 6 June and explain why you want the vaccine. If you go on to have the vaccine, your parents will get an email to let them know this has happened.</p>
+  <p>If you want to give permission yourself, you can talk to a nurse on {{ sessionDate | date("d MMMM") }} and explain why you want the vaccine. If you go on to have the vaccine, your parents will get an email to let them know this has happened.</p>
 
   <h2 class="nhsuk-heading-m">What if I don’t want the vaccine?</h2>
 
   <p>You can ask your parents to let us know that you don’t want the vaccine.</p>
 
-  <p>If they want you to have the vaccine but you don’t, you can say this to the nurse when you see them on 6 June.</p>
+  <p>If they want you to have the vaccine but you don’t, you can say this to the nurse when you see them on {{ sessionDate | date("d MMMM") }}.</p>
 
   <h2 class="nhsuk-heading-m">What should I do now?</h2>
 

--- a/app/views/emails/hpv-vaccine-given.html
+++ b/app/views/emails/hpv-vaccine-given.html
@@ -6,14 +6,14 @@
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>{{ childName }} got the first dose of their HPV vaccination at Hele’s School today. </p>
+  <p>{{ childName }} got the first dose of their HPV vaccination at {{ sessionSchool }} today. </p>
 
   <p>We suggest you record the following details in their red book (also known as their personal child health record):</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>Vaccination: HPV first dose</li>
     <li>Vaccine: Gardasil 9</li>
-    <li>Date of vaccination: 6 June 2023</li>
+    <li>Date of vaccination: {{ sessionDate | govukDate }}</li>
     <li>Batch number: PH3539</li>
   </ul>
 

--- a/app/views/sais/campaigns.html
+++ b/app/views/sais/campaigns.html
@@ -36,7 +36,7 @@
                   Flu vaccine
                 </td>
                 <td>
-                  22 November
+                  24 November
                 </td>
                 <td>
                   32%

--- a/app/views/school/campaign/flu-preview.html
+++ b/app/views/school/campaign/flu-preview.html
@@ -18,7 +18,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h1 class="nhsuk-heading-xl">
-        <span class="nhsuk-caption-xl">22 November 2022</span>
+        <span class="nhsuk-caption-xl">{{ sessionDate | govukDate }}</span>
         {{ title }}
       </h1>
     </div>
@@ -28,12 +28,12 @@
     <div class="govuk-grid-row nhsuk-u-margin-top-6">
       <div class="govuk-grid-column-two-thirds">
         <p>
-          A local health team are coming to <b>St Mary’s Primary School</b> on Tuesday 22 November 2022 to give flu vaccines.
+          A local health team are coming to <b>St Mary’s Primary School</b> on {{ sessionDate | date("cccc d MMMM") }} to give flu vaccines.
         </p>
 
         <h2 class="nhsuk-heading-m">Please give or refuse consent</h2>
 
-        <p>If you want your child to receive this vaccine at school, you need to give consent by 21 November 2022 (2 days before the vaccination).</p>
+        <p>If you want your child to receive this vaccine at school, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }} (2 days before the vaccination).</p>
 
         <p>
           <a href="/start">Give or refuse consent for the flu vaccination</a>
@@ -70,9 +70,9 @@
 
       <h2 class="nhsuk-heading-m">Preview</h2>
       {{ card({
-        "heading": "Subject: Flu vaccination on 22 November",
-        "headingLevel": "2",
-        "descriptionHtml": html
+        heading: "Subject: Flu vaccination on " + (sessionDate | date("d MMMM")),
+        headingLevel: 2,
+        descriptionHtml: html
       }) }}
     </div>
   </div>

--- a/app/views/school/campaign/flu-reminder-preview.html
+++ b/app/views/school/campaign/flu-reminder-preview.html
@@ -18,7 +18,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h1 class="nhsuk-heading-xl">
-        <span class="nhsuk-caption-xl">22 November 2022</span>
+        <span class="nhsuk-caption-xl">{{ sessionDate | govukDate }}</span>
         {{ title }}
       </h1>
 
@@ -30,10 +30,10 @@
     <div class="govuk-grid-row nhsuk-u-margin-top-6">
       <div class="govuk-grid-column-two-thirds">
         <p>
-          We wrote to you recently about a visit by a local health team to <b>St Mary’s Primary School</b> on Tuesday 22 November 2022.
+          We wrote to you recently about a visit by a local health team to <b>St Mary’s Primary School</b> on {{ sessionDate | date("cccc d MMMM") }}.
         </p>
 
-        <p>If you want your child to receive a flu vaccine during this visit, you need to give consent by 21 November 2022 (2 days before the vaccination).</p>
+        <p>If you want your child to receive a flu vaccine during this visit, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }} (2 days before the vaccination).</p>
 
         <p>This will take less than 5 minutes.</p>
 
@@ -74,9 +74,9 @@
 
       <h2 class="nhsuk-heading-m">Preview</h2>
       {{ card({
-        "heading": "Subject: Respond to our request for consent by 20&nbsp;November" | safe,
-        "headingLevel": "2",
-        "descriptionHtml": html
+        heading: "Subject: Respond to our request for consent by " + (sessionDate | date("d MMMM")),
+        headingLevel: 2,
+        descriptionHtml: html
       }) }}
     </div>
   </div>

--- a/app/views/school/campaign/flu.html
+++ b/app/views/school/campaign/flu.html
@@ -12,11 +12,11 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
       <h1 class="nhsuk-heading-xl">
-        <span class="nhsuk-caption-xl">22 November 2022</span>
+        <span class="nhsuk-caption-xl">{{ sessionDate | govukDate }}</span>
         {{ title }}
       </h1>
 
-      <p>East Sussex SAIS team are running a flu vaccine clinic at your school on 24 November 2022.</p>
+      <p>East Sussex SAIS team are running a flu vaccine clinic at your school on {{ sessionDate | govukDate }}.</p>
 
       <p>You need to send a consent request for each eligible child. This might be by email, text message or paper form.</p>
 

--- a/app/views/school/campaigns.html
+++ b/app/views/school/campaigns.html
@@ -9,7 +9,7 @@
           <h1 class="nhsuk-heading-xl">{{ title }}</h1>
 
           <h2 class="nhsuk-heading-l">
-            <a href="/school/campaign/flu">Flu vaccine – 24 November 2022</a>
+            <a href="/school/campaign/flu">Flu vaccine – {{ sessionDate | govukDate }}</a>
           </h2>
 
           <h2 class="nhsuk-heading-l">


### PR DESCRIPTION
We show the school a campaign is being run at, the deadline for consent, and the day a session is taking place a number of times throughout the app, but these values are currently hard coded.

This PR adds this values as local data variables, and uses the date filter to format the deadline and session dates.