### PR TITLE
Use transactional header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,10 +16,6 @@ $govuk-assets-path: "/govuk/assets/";
 @import "unbranded";
 @import "email";
 
-.nhsuk-header__service-name {
-  max-width: none;
-}
-
 .app-panel h1 {
   @include nhsuk-font(32, $weight: bold);
 }

--- a/app/views/consent/confirmation-contraindications.html
+++ b/app/views/consent/confirmation-contraindications.html
@@ -20,7 +20,7 @@
 {% endset %}
 
 {% set hideButton = true %}
-{% block pageNavigation %}{% endblock %}
+{% block outerContent %}{% endblock %}
 
 {% block form %}
   <h1 class="nhsuk-heading-l">{{ title }}</h1>

--- a/app/views/consent/confirmation-no-consent.html
+++ b/app/views/consent/confirmation-no-consent.html
@@ -11,7 +11,7 @@
 {% endset %}
 
 {% set hideButton = true %}
-{% block pageNavigation %}{% endblock %}
+{% block outerContent %}{% endblock %}
 
 {% block form %}
   <h1 class="nhsuk-heading-l">{{ title }}</h1>

--- a/app/views/consent/confirmation.html
+++ b/app/views/consent/confirmation.html
@@ -21,7 +21,7 @@
 {% endset %}
 
 {% set hideButton = true %}
-{% block pageNavigation %}{% endblock %}
+{% block outerContent %}{% endblock %}
 
 {% block form %}
   {{ govukPanel({

--- a/app/views/dpt/confirmation.html
+++ b/app/views/dpt/confirmation.html
@@ -9,7 +9,7 @@
 {% endset %}
 
 {% set hideButton = true %}
-{% block pageNavigation %}{% endblock %}
+{% block outerContent %}{% endblock %}
 
 {% block form %}
   <h1 class="nhsuk-heading-xl">{{ title }}</h1>

--- a/app/views/flu/confirmation-jab-contact.html
+++ b/app/views/flu/confirmation-jab-contact.html
@@ -1,7 +1,7 @@
 {% extends "layouts/wizard.html" %}
 {% set title = "Your child will not get a nasal flu vaccination at school" %}
 {% set hideButton = true %}
-{% block pageNavigation %}{% endblock %}
+{% block outerContent %}{% endblock %}
 
 {% block form %}
   <h1 class="nhsuk-heading-l">{{ title }}</h1>

--- a/app/views/layouts/default.html
+++ b/app/views/layouts/default.html
@@ -1,5 +1,7 @@
 {% extends "template.njk" %}
 
+{% set mainClasses = "nhsuk-main-wrapper--s" %}
+
 {% block head %}
   <link rel="stylesheet" href="/public/application.css" media="all">
   <script src="/public/application.js" defer></script>
@@ -15,13 +17,12 @@
 
 {% block header %}
   {{ header({
-    service: {
+    transactionalService: {
       name: serviceName,
       href: "/"
     },
     showNav: "false",
-    showSearch: "false",
-    containerClasses: "nhsuk-width-container"
+    showSearch: "false"
   }) }}
 {% endblock %}
 

--- a/app/views/layouts/default.html
+++ b/app/views/layouts/default.html
@@ -26,10 +26,6 @@
   }) }}
 {% endblock %}
 
-{% block beforeContent %}
-  {% block pageNavigation %}{% endblock %}
-{% endblock %}
-
 {% block footer %}
   {{ footer({
     links: [

--- a/app/views/layouts/wizard.html
+++ b/app/views/layouts/wizard.html
@@ -1,14 +1,10 @@
 {% extends "layouts/default.html" %}
-{% set mainClasses = "nhsuk-main-wrapper--s" %}
-{% block pageNavigation %}
-  {% if paths.back %}
-    <div class="nhsuk-width-container">
-      {{ backLink({
-        href: paths.back,
-        classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
-      }) }}
-    </div>
-  {% endif %}
+
+{% block outerContent %}
+  {{ backLink({
+    href: paths.back,
+    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+  }) if paths.back }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Use transactional header (which has a slightly smaller NHS logo and doesn’t wrap the service name). Also use `outerContent` block for page navigation which saves duplicating an `nhsuk-width-container` (this being the recommendation in the NHS Design System).