### PR TITLE
Emails: ensure informed consent and add information about consenting by phone

### DIFF
--- a/app/views/emails/flu-consent.html
+++ b/app/views/emails/flu-consent.html
@@ -11,6 +11,8 @@
 
   <p>By preventing the spread of flu, the vaccine also protects others who are vulnerable, such as babies and older people.</p>
 
+  <p>The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so it is recommended to have it again this year.</p>
+
   <h2 class="nhsuk-heading-m">Please give or refuse consent</h2>
 
   <p>If you want your child to get this vaccine at school, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
@@ -22,8 +24,6 @@
   <p>Responding will take less than 5 minutes.</p>
 
   <h2 class="nhsuk-heading-m">About the flu vaccine</h2>
-
-  <p>The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so it is recommended to have it again this year.</p>
 
   <p>The nasal spray contains gelatine. If your child does not use gelatine products, or the nasal spray is not suitable for medical reasons, they could have an injection instead.</p>
 

--- a/app/views/emails/flu-consent.html
+++ b/app/views/emails/flu-consent.html
@@ -32,5 +32,10 @@
   <p><a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1165161/UKHSA-12652-protecting-your-child-against-flu-information-for-parents-and-carers.pdf">Find out more about protecting your child against flu</a></p>
 
   <p><a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107767/UKHSA-12462-vaccines-porcine-gelatine-English.pdf">Find out more about the use of gelatine in the flu vaccine (including the views of faith communities)</a></p>
+
+  <h2 class="nhsuk-heading-m">If you have trouble using the online form</h2>
+
+  <p>If you have any trouble using the online form, you can respond over the phone using the contact details below.</p>
+
   {% include "emails/_contact.html" %}
 {% endblock %}

--- a/app/views/emails/flu-reminder.html
+++ b/app/views/emails/flu-reminder.html
@@ -23,5 +23,9 @@
 
   <p><a href="https://www.nhs.uk/conditions/vaccinations/child-flu-vaccine/">Find out more about the flu vaccine on NHS.UK</a></p>
 
+  <h2 class="nhsuk-heading-m">If you have trouble using the online form</h2>
+
+  <p>If you have any trouble using the online form, you can respond over the phone using the contact details below.</p>
+
   {% include "emails/_contact.html" %}
 {% endblock %}

--- a/app/views/emails/flu-reminder.html
+++ b/app/views/emails/flu-reminder.html
@@ -5,7 +5,9 @@
 {% block email %}
   <p>We wrote to you recently about a visit by a local health team to {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.</p>
 
-  <p>If you want your child to get the flu vaccine during this visit, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
+  <p>If you want your child to get the flu vaccination during this visit, you need to give consent by {{ deadlineDate | date("cccc d MMMM") }}.</p>
+
+  <p>The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so we recommend they have it again this year.</p>
 
   <p>
     <a href="/flu/start">Give or refuse consent for the flu vaccination</a>


### PR DESCRIPTION
In our current initial email to parents, we give information about the flu vaccination after we ask for consent. This PR switches the order in the initial and reminder emails so that parents are giving informed consent.

It also adds a section explaining that parents can respond over the phone if they have any trouble using the online form.