### PR TITLE
Update content for confirmation page and email

### DIFF
--- a/app/views/consent/confirmation-contraindications.html
+++ b/app/views/consent/confirmation-contraindications.html
@@ -25,9 +25,13 @@
 {% block form %}
   <h1 class="nhsuk-heading-l">{{ title }}</h1>
 
-  <p>A member of our health team will be in touch to discuss your answers to the health questions.</p>
-
-  <p>Our health team will confirm if your child will get their {% if vaccine == "DPT" and consentForBoth %}vaccinations{% else %}vaccination{% endif %} at school.</p>
+  <p>As you answered ‘yes’ to some of the health questions, we need to check
+  the {% if vaccine == "DPT" and consentForBoth %}
+    vaccinations are
+  {% else %}
+    vaccination is
+  {% endif %} suitable for {{ childName }}. We’ll review your answers and
+  get in touch again soon.</p>
 
   <p>We’ve sent confirmation of your consent to jane.doe@example.com.</p>
 {% endblock %}

--- a/app/views/emails/flu-refusal-confirmation.html
+++ b/app/views/emails/flu-refusal-confirmation.html
@@ -6,7 +6,7 @@
 {% block email %}
   <p>Dear {{ name }},</p>
 
-  <p>You’ve told us you do not want {{ childName }} to have their flu vaccination at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}.Please let {{ childName.split(" ") | first }} know they will not be vaccinated against flu in school.</p>
+  <p>You’ve told us you do not want {{ childName }} to have their flu vaccination at {{ sessionSchool }} on {{ sessionDate | date("cccc d MMMM") }}. Please let {{ childName.split(" ") | first }} know they will not be vaccinated against flu in school.</p>
 
   <p>If you change your mind, please get in touch with us. You can email example@nhs.uk or call 01234 321456.</p>
 


### PR DESCRIPTION
Aligns the content in the confirmation page to the email.

![image](https://github.com/nhsuk/consent-for-vaccinations-prototype/assets/1650875/6534da43-014e-4865-b7f7-8211892b4bca)
